### PR TITLE
Add support for service accounts in nomad-bridge chart

### DIFF
--- a/charts/nomad-bridge/Chart.yaml
+++ b/charts/nomad-bridge/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: nomad-bridge
 description: A Helm Chart that encapsulates the deployment of the Nomad bridge agents
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 0.0.1

--- a/charts/nomad-bridge/README.md
+++ b/charts/nomad-bridge/README.md
@@ -51,7 +51,7 @@ A Helm Chart that encapsulates the deployment of the Nomad bridge agents
 | relayer.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"20Mi"}}` | Relayer container's resource requests and limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | serviceAccount | object | `{"create":true,"name":""}` | ServiceAccount configuration  |
 | serviceAccount.create | bool | `true` | Create service account |
-| serviceAccount.name | string | `""` | Name of service account to use if create is false |
+| serviceAccount.name | string | `""` | Name of service account to use if create is true |
 | storage | object | `{"accessModes":"ReadWriteOnce","capacity":"10Gi","mountPath":"/usr/share/nomad","storageClass":"standard"}` | Persistent Storage pod configuration  |
 | storage.accessModes | string | `"ReadWriteOnce"` | AccessModes for Persistent Volume(s) |
 | storage.capacity | string | `"10Gi"` | Mount path for Nomad DB Persistent Volume(s)  |

--- a/charts/nomad-bridge/README.md
+++ b/charts/nomad-bridge/README.md
@@ -1,6 +1,6 @@
 # nomad-bridge
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
+![Version: 0.1.3](https://img.shields.io/badge/Version-0.1.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.1](https://img.shields.io/badge/AppVersion-0.0.1-informational?style=flat-square)
 
 A Helm Chart that encapsulates the deployment of the Nomad bridge agents
 
@@ -8,59 +8,72 @@ A Helm Chart that encapsulates the deployment of the Nomad bridge agents
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| aws | object | `{}` | Base64 encoded AWS Credentials used by Nomad agent to sign transactions and store proofs to S3 |
-| commonAnnotations | object | `{"prometheus.io/port":"9090","prometheus.io/scrape":"true"}` | Add extra annotations to all pods |
-| commonEnvVars | list | `[]` | Common environment variables to add all pods |
-| commonLabels | object | `{}` | Add extra labels to all pods |
-| containerSecurityContext | object | `{"enabled":true,"runAsUser":1001}` | Configure Container Security Context (only main container) ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container |
+| aws | object | `{}` | Base64 encoded AWS Credentials used by Nomad agent to sign transactions and store proofs to S3 # Example: # aws: #   AWS_ACCESS_KEY_ID: '1234567890' #   AWS_SECRET_ACCESS_KEY: 'abcdefghijklmnopqrstuvwxyz' |
+| commonAnnotations | object | `{"prometheus.io/port":"9090","prometheus.io/scrape":"true"}` | Add extra annotations to all pods  |
+| commonEnvFrom | list | `[]` | Common environment variables from a config/secret file |
+| commonEnvVars | list | `[]` | Common environment variables to add all pods  |
+| commonLabels | object | `{}` | Add extra labels to all pods  |
+| containerSecurityContext | object | `{"enabled":true,"runAsUser":1001}` | Configure Container Security Context (only main container) ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container  |
 | containerSecurityContext.enabled | bool | `true` | Enable container security context |
 | containerSecurityContext.runAsUser | int | `1001` | User ID for the container   |
-| fullnameOverride | string | `""` | String to fully override agent.fullname template with a string |
+| fullnameOverride | string | `""` | String to fully override agent.fullname template with a string  |
+| image | object | `{"tag":"latest"}` | Default Nomad agent docker image configuration (immutable image tags are recommended) |
 | kathy.enabled | bool | `false` | Enable Nomad agent kathy |
+| kathy.envFrom | list | `[]` | Environment variables from a config/secret file |
 | kathy.envVars | list | `[]` | Environment variables to add Nomad agent kathy pod |
-| kathy.image | object | `{"pullPolicy":"Always","registry":"gcr.io","repository":"nomad-xyz/nomad-agent","tag":"latest"}` | Nomad agent kathy docker image configuration (immutable image tags are recommended) |
+| kathy.image | object | `{"pullPolicy":"Always","registry":"gcr.io","repository":"nomad-xyz/nomad-agent"}` | Nomad agent kathy docker image configuration (immutable image tags are recommended) |
 | kathy.podAnnotations | object | `{}` | Add extra annotations to the pod |
 | kathy.podLabels | object | `{}` | Add extra labels to the pods |
+| kathy.replicas | int | `1` | Number of instances of kathy |
 | kathy.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"20Mi"}}` | Kathy container's resource requests and limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| metrics | object | `{"port":"9090"}` | Container port exposing Nomad agent metrics |
-| nameOverride | string | `""` | String to partially override agent.fullname template with a string (will prepend the release name) |
-| podSecurityContext | object | `{"enabled":true,"fsGroup":1001}` | Configure Pods Security Context ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod |
+| metrics | object | `{"port":"9090"}` | Container port exposing Nomad agent metrics  |
+| nameOverride | string | `""` | String to partially override agent.fullname template with a string (will prepend the release name)  |
+| podSecurityContext | object | `{"enabled":true,"fsGroup":1001}` | Configure Pods Security Context ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod  |
 | podSecurityContext.enabled | bool | `true` | Enable pod security context |
 | podSecurityContext.fsGroup | int | `1001` | fsGroup ID for the pod |
 | processor.enabled | bool | `true` | Enable Nomad agent processor |
+| processor.envFrom | list | `[]` | Environment variables from a config/secret file |
 | processor.envVars | list | `[]` | Environment variables to add Nomad agent processor pod |
 | processor.image.pullPolicy | string | `"Always"` |  |
 | processor.image.registry | string | `"gcr.io"` |  |
 | processor.image.repository | string | `"nomad-xyz/nomad-agent"` |  |
-| processor.image.tag | string | `"latest"` |  |
 | processor.podAnnotations | object | `{}` | Add extra annotations to the pod |
 | processor.podLabels | object | `{}` | Add extra labels to the pods |
+| processor.replicas | int | `1` | Number of instances of processor |
 | processor.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"20Mi"}}` | Processor container's resource requests and limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | relayer.enabled | bool | `true` | Enable Nomad agent relayer |
+| relayer.envFrom | list | `[]` | Environment variables from a config/secret file |
 | relayer.envVars | list | `[]` | Environment variables to add Nomad agent relayer pod |
-| relayer.image | object | `{"pullPolicy":"Always","registry":"gcr.io","repository":"nomad-xyz/nomad-agent","tag":"latest"}` | Nomad agent relayer docker image configuration (immutable image tags are recommended) |
+| relayer.image | object | `{"pullPolicy":"Always","registry":"gcr.io","repository":"nomad-xyz/nomad-agent"}` | Nomad agent relayer docker image configuration (immutable image tags are recommended) |
 | relayer.podAnnotations | object | `{}` | Add extra annotations to the pod |
 | relayer.podLabels | object | `{}` | Add extra labels to the pods |
+| relayer.replicas | int | `1` | Number of instances of relayer |
 | relayer.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"20Mi"}}` | Relayer container's resource requests and limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
-| storage | object | `{"accessModes":"ReadWriteOnce","capacity":"10Gi","mountPath":"/usr/share/nomad","storageClass":"standard"}` | Persistent Storage pod configuration |
+| serviceAccount | object | `{"create":true,"name":""}` | ServiceAccount configuration  |
+| serviceAccount.create | bool | `true` | Create service account |
+| serviceAccount.name | string | `""` | Name of service account to use if create is false |
+| storage | object | `{"accessModes":"ReadWriteOnce","capacity":"10Gi","mountPath":"/usr/share/nomad","storageClass":"standard"}` | Persistent Storage pod configuration  |
 | storage.accessModes | string | `"ReadWriteOnce"` | AccessModes for Persistent Volume(s) |
 | storage.capacity | string | `"10Gi"` | Mount path for Nomad DB Persistent Volume(s)  |
 | storage.storageClass | string | `"standard"` | StorageClass for Persistent Volume(s) |
 | updater.enabled | bool | `true` | Enable Nomad agent updater |
+| updater.envFrom | list | `[]` | Environment variables from a config/secret file |
 | updater.envVars | list | `[]` | Environment variables to add Nomad agent updater pod |
-| updater.image | object | `{"pullPolicy":"Always","registry":"gcr.io","repository":"nomad-xyz/nomad-agent","tag":"latest"}` | Nomad agent updater docker image configuration (immutable image tags are recommended) |
+| updater.image | object | `{"pullPolicy":"Always","registry":"gcr.io","repository":"nomad-xyz/nomad-agent"}` | Nomad agent updater docker image configuration (immutable image tags are recommended) |
 | updater.podAnnotations | object | `{}` | Add extra annotations to the pod |
 | updater.podLabels | object | `{}` | Add extra labels to the pods |
+| updater.replicas | int | `1` | Number of instances of updater (Warning: you should always have only one instance of updater running at any given time) |
 | updater.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"20Mi"}}` | Updater container's resource requests and limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 | watcher.enabled | bool | `false` | Enable Nomad agent watcher |
+| watcher.envFrom | list | `[]` | Environment variables from a config/secret file |
 | watcher.envVars | list | `[]` | Environment variables to add Nomad agent watcher pod |
 | watcher.image.pullPolicy | string | `"Always"` |  |
 | watcher.image.registry | string | `"gcr.io"` |  |
 | watcher.image.repository | string | `"nomad-xyz/nomad-agent"` |  |
-| watcher.image.tag | string | `"latest"` |  |
 | watcher.podAnnotations | object | `{}` | Add extra annotations to the pod |
 | watcher.podLabels | object | `{}` | Add extra labels to the pods |
+| watcher.replicas | int | `1` | Number of instances of watcher |
 | watcher.resources | object | `{"limits":{"cpu":"50m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"20Mi"}}` | Watcher container's resource requests and limits ref: https://kubernetes.io/docs/user-guide/compute-resources/ |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.7.0](https://github.com/norwoodj/helm-docs/releases/v1.7.0)
+Autogenerated from chart metadata using [helm-docs v1.10.0](https://github.com/norwoodj/helm-docs/releases/v1.10.0)

--- a/charts/nomad-bridge/templates/_helpers.tpl
+++ b/charts/nomad-bridge/templates/_helpers.tpl
@@ -55,6 +55,8 @@ Create the name of the service account to use
 */}}
 {{- define "agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-serviceAccountName:  {{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/charts/nomad-bridge/templates/_helpers.tpl
+++ b/charts/nomad-bridge/templates/_helpers.tpl
@@ -55,8 +55,6 @@ Create the name of the service account to use
 */}}
 {{- define "agent.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+serviceAccountName:  {{- default (include "agent.fullname" .) .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}

--- a/charts/nomad-bridge/templates/config/secret-aws-creds.yaml
+++ b/charts/nomad-bridge/templates/config/secret-aws-creds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.aws }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,3 +16,4 @@ data:
   {{- range $aws_key, $aws_value := .Values.aws }}
   {{ $aws_key | upper }}: {{ $aws_value | b64enc | quote }}
   {{- end }}
+{{- end }}

--- a/charts/nomad-bridge/templates/config/serviceaccount.yaml
+++ b/charts/nomad-bridge/templates/config/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "agent.serviceAccountName" . }}
+  labels:
+    {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations: 
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/nomad-bridge/templates/config/serviceaccount.yaml
+++ b/charts/nomad-bridge/templates/config/serviceaccount.yaml
@@ -3,10 +3,11 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "agent.serviceAccountName" . }}
-  labels:
-    {{- include "agent.labels" . | nindent 4 }}
-  {{- with .Values.commonAnnotations }}
-  annotations: 
+  labels: {{- include "agent.labels" . | nindent 4 }}
+  {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.commonAnnotations }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 {{- end }}

--- a/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
+++ b/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
+      {{ include "agent.serviceAccountName" . | nindent 8 }}
       {{- with .Values.kathy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
+++ b/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{- include "agent.serviceAccountName" . | nindent 6 }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.kathy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
+++ b/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 6 }}
+      {{- include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.kathy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
+++ b/charts/nomad-bridge/templates/kathy/kathy-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 8 }}
+      {{ include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.kathy.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
+++ b/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 8 }}
+       {{ include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.processor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
+++ b/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
+      {{ include "agent.serviceAccountName" . | nindent 8 }}
       {{- with .Values.processor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
+++ b/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-       {{ include "agent.serviceAccountName" . | nindent 6 }}
+      {{- include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.processor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
+++ b/charts/nomad-bridge/templates/processor/processor-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{- include "agent.serviceAccountName" . | nindent 6 }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.processor.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
+++ b/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 8 }}
+      {{ include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.relayer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
+++ b/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
+      {{ include "agent.serviceAccountName" . | nindent 8 }}
       {{- with .Values.relayer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
+++ b/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 6 }}
+      {{- include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.relayer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
+++ b/charts/nomad-bridge/templates/relayer/relayer-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{- include "agent.serviceAccountName" . | nindent 6 }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.relayer.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
+++ b/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 8 }}
+      {{ include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.updater.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
+++ b/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
+      {{ include "agent.serviceAccountName" . | nindent 8 }}
       {{- with .Values.updater.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
+++ b/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 6 }}
+      {{- include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.updater.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
+++ b/charts/nomad-bridge/templates/updater/updater-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{- include "agent.serviceAccountName" . | nindent 6 }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.updater.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
+++ b/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 6 }}
+      {{- include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.watcher.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
+++ b/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
@@ -66,7 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{ include "agent.serviceAccountName" . | nindent 8 }}
+      {{ include "agent.serviceAccountName" . | nindent 6 }}
       {{- with .Values.watcher.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
+++ b/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
@@ -66,6 +66,7 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
+      {{ include "agent.serviceAccountName" . | nindent 8 }}
       {{- with .Values.watcher.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
+++ b/charts/nomad-bridge/templates/watcher/watcher-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           ports: 
             - name: metrics
               containerPort: {{ .Values.metrics.port }}
-      {{- include "agent.serviceAccountName" . | nindent 6 }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "agent.serviceAccountName" . }}
+      {{- end }}
       {{- with .Values.watcher.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/nomad-bridge/values.yaml
+++ b/charts/nomad-bridge/values.yaml
@@ -7,6 +7,14 @@ nameOverride: ""
 #
 fullnameOverride: ""
 
+# serviceAccount -- ServiceAccount configuration
+#
+serviceAccount:
+  # serviceAccount.create -- Create service account
+  create: true
+  # serviceAccount.name -- Name of service account to use if create is false
+  name: ""
+
 # -- Configure Pods Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 #


### PR DESCRIPTION
## SUMMARY
Add support for service accounts in nomad-bridge chart

```yaml
# when Values.serviceAccount.create

❯ helm template .
---
# Source: nomad-bridge/templates/config/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: release-name-nomad-bridge
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
    prometheus.io/port: "9090"
    prometheus.io/scrape: "true"
---
# Source: nomad-bridge/templates/processor/processor-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-nomad-bridge-processor
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: processor
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: nomad-bridge
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: processor
  replicas: 1
  serviceName: release-name-nomad-bridge-processor-svc
  template:
    metadata:
      annotations:
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      labels:
        helm.sh/chart: nomad-bridge-0.1.3
        app.kubernetes.io/name: nomad-bridge
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: processor
    spec:
      terminationGracePeriodSeconds: 10
      securityContext:
        fsGroup: 1001
      containers:
        - name: nomad-agent
          image: "gcr.io/nomad-xyz/nomad-agent:latest"
          imagePullPolicy: Always
          securityContext:
            runAsUser: 1001
          command: ["./processor"]
          envFrom:
            - secretRef:
                name: release-name-nomad-bridge-awscreds
          env:
          resources:
            limits:
              cpu: 50m
              memory: 50Mi
            requests:
              cpu: 10m
              memory: 20Mi
          volumeMounts:
            - name: state
              mountPath: /usr/share/nomad
          ports: 
            - name: metrics
              containerPort: 9090
      serviceAccountName: release-name-nomad-bridge
  volumeClaimTemplates:
  - metadata:
      name: state
    spec:
      storageClassName: standard
      accessModes: [ ReadWriteOnce ]
      resources:
        requests:
          storage: 10Gi
---
# Source: nomad-bridge/templates/relayer/relayer-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-nomad-bridge-relayer
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: relayer
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: nomad-bridge
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: relayer
  replicas: 1
  serviceName: release-name-nomad-bridge-relayer-svc
  template:
    metadata:
      annotations:
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      labels:
        helm.sh/chart: nomad-bridge-0.1.3
        app.kubernetes.io/name: nomad-bridge
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: relayer
    spec:
      terminationGracePeriodSeconds: 10
      securityContext:
        fsGroup: 1001
      containers:
        - name: nomad-agent
          image: "gcr.io/nomad-xyz/nomad-agent:latest"
          imagePullPolicy: Always
          securityContext:
            runAsUser: 1001
          command: ["./relayer"]
          envFrom:
            - secretRef:
                name: release-name-nomad-bridge-awscreds
          env:
          resources:
            limits:
              cpu: 50m
              memory: 50Mi
            requests:
              cpu: 10m
              memory: 20Mi
          volumeMounts:
            - name: state
              mountPath: /usr/share/nomad
          ports: 
            - name: metrics
              containerPort: 9090
      serviceAccountName: release-name-nomad-bridge
  volumeClaimTemplates:
  - metadata:
      name: state
    spec:
      storageClassName: standard
      accessModes: [ ReadWriteOnce ]
      resources:
        requests:
          storage: 10Gi
---
# Source: nomad-bridge/templates/updater/updater-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-nomad-bridge-updater
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: updater
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: nomad-bridge
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: updater
  replicas: 1
  serviceName: release-name-nomad-bridge-updater-svc
  template:
    metadata:
      annotations:
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      labels:
        helm.sh/chart: nomad-bridge-0.1.3
        app.kubernetes.io/name: nomad-bridge
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: updater
    spec:
      terminationGracePeriodSeconds: 10
      securityContext:
        fsGroup: 1001
      containers:
        - name: nomad-agent
          image: "gcr.io/nomad-xyz/nomad-agent:latest"
          imagePullPolicy: Always
          securityContext:
            runAsUser: 1001
          command: ["./updater"]
          envFrom:
            - secretRef:
                name: release-name-nomad-bridge-awscreds
          env:
          resources:
            limits:
              cpu: 50m
              memory: 50Mi
            requests:
              cpu: 10m
              memory: 20Mi
          volumeMounts:
            - name: state
              mountPath: /usr/share/nomad
          ports: 
            - name: metrics
              containerPort: 9090
      serviceAccountName: release-name-nomad-bridge
  volumeClaimTemplates:
  - metadata:
      name: state
    spec:
      storageClassName: standard
      accessModes: [ ReadWriteOnce ]
      resources:
        requests:
          storage: 10Gi
```

```yaml
# when ! .Values.serviceAccount.create

❯ helm template .
---
# Source: nomad-bridge/templates/processor/processor-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-nomad-bridge-processor
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: processor
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: nomad-bridge
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: processor
  replicas: 1
  serviceName: release-name-nomad-bridge-processor-svc
  template:
    metadata:
      annotations:
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      labels:
        helm.sh/chart: nomad-bridge-0.1.3
        app.kubernetes.io/name: nomad-bridge
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: processor
    spec:
      terminationGracePeriodSeconds: 10
      securityContext:
        fsGroup: 1001
      containers:
        - name: nomad-agent
          image: "gcr.io/nomad-xyz/nomad-agent:latest"
          imagePullPolicy: Always
          securityContext:
            runAsUser: 1001
          command: ["./processor"]
          envFrom:
            - secretRef:
                name: release-name-nomad-bridge-awscreds
          env:
          resources:
            limits:
              cpu: 50m
              memory: 50Mi
            requests:
              cpu: 10m
              memory: 20Mi
          volumeMounts:
            - name: state
              mountPath: /usr/share/nomad
          ports: 
            - name: metrics
              containerPort: 9090
  volumeClaimTemplates:
  - metadata:
      name: state
    spec:
      storageClassName: standard
      accessModes: [ ReadWriteOnce ]
      resources:
        requests:
          storage: 10Gi
---
# Source: nomad-bridge/templates/relayer/relayer-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-nomad-bridge-relayer
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: relayer
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: nomad-bridge
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: relayer
  replicas: 1
  serviceName: release-name-nomad-bridge-relayer-svc
  template:
    metadata:
      annotations:
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      labels:
        helm.sh/chart: nomad-bridge-0.1.3
        app.kubernetes.io/name: nomad-bridge
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: relayer
    spec:
      terminationGracePeriodSeconds: 10
      securityContext:
        fsGroup: 1001
      containers:
        - name: nomad-agent
          image: "gcr.io/nomad-xyz/nomad-agent:latest"
          imagePullPolicy: Always
          securityContext:
            runAsUser: 1001
          command: ["./relayer"]
          envFrom:
            - secretRef:
                name: release-name-nomad-bridge-awscreds
          env:
          resources:
            limits:
              cpu: 50m
              memory: 50Mi
            requests:
              cpu: 10m
              memory: 20Mi
          volumeMounts:
            - name: state
              mountPath: /usr/share/nomad
          ports: 
            - name: metrics
              containerPort: 9090
  volumeClaimTemplates:
  - metadata:
      name: state
    spec:
      storageClassName: standard
      accessModes: [ ReadWriteOnce ]
      resources:
        requests:
          storage: 10Gi
---
# Source: nomad-bridge/templates/updater/updater-statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-nomad-bridge-updater
  labels:
    helm.sh/chart: nomad-bridge-0.1.3
    app.kubernetes.io/name: nomad-bridge
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: updater
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: nomad-bridge
      app.kubernetes.io/instance: release-name
      app.kubernetes.io/component: updater
  replicas: 1
  serviceName: release-name-nomad-bridge-updater-svc
  template:
    metadata:
      annotations:
        prometheus.io/port: "9090"
        prometheus.io/scrape: "true"
      labels:
        helm.sh/chart: nomad-bridge-0.1.3
        app.kubernetes.io/name: nomad-bridge
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "0.0.1"
        app.kubernetes.io/managed-by: Helm
        app.kubernetes.io/component: updater
    spec:
      terminationGracePeriodSeconds: 10
      securityContext:
        fsGroup: 1001
      containers:
        - name: nomad-agent
          image: "gcr.io/nomad-xyz/nomad-agent:latest"
          imagePullPolicy: Always
          securityContext:
            runAsUser: 1001
          command: ["./updater"]
          envFrom:
            - secretRef:
                name: release-name-nomad-bridge-awscreds
          env:
          resources:
            limits:
              cpu: 50m
              memory: 50Mi
            requests:
              cpu: 10m
              memory: 20Mi
          volumeMounts:
            - name: state
              mountPath: /usr/share/nomad
          ports: 
            - name: metrics
              containerPort: 9090
  volumeClaimTemplates:
  - metadata:
      name: state
    spec:
      storageClassName: standard
      accessModes: [ ReadWriteOnce ]
      resources:
        requests:
          storage: 10Gi
```