### PR TITLE
fix: downgrade postgres version to 11.7 to be compatible with current version

### DIFF
--- a/charts/nomad-indexer/CHANGELOG.md
+++ b/charts/nomad-indexer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.0.16
+
+- downgrade postgres version from v14 -> v11.6 to be compatible with current postgres version
+
 ## 0.0.15
 
 - Supported prometheus-postgres-exporter

--- a/charts/nomad-indexer/CHANGELOG.md
+++ b/charts/nomad-indexer/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 0.0.16
 
-- downgrade postgres version from v14 -> v11.6 to be compatible with current postgres version
+- downgrade postgres version from v14 -> v11.7.0-debian-10-r26 to be compatible with staging/prod postgres version
 
 ## 0.0.15
 

--- a/charts/nomad-indexer/Chart.yaml
+++ b/charts/nomad-indexer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.15
+version: 0.0.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nomad-indexer/values.yaml
+++ b/charts/nomad-indexer/values.yaml
@@ -75,7 +75,7 @@ postgresql:
   # ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml#L94
   # ref: https://docs.bitnami.com/kubernetes/infrastructure/postgresql/configuration/change-image-version/
   image:
-    tag: 11.16.0
+    tag: 11.7.0-debian-10-r26
 
 prometheus-postgres-exporter:
   # ref: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-postgres-exporter/values.yaml

--- a/charts/nomad-indexer/values.yaml
+++ b/charts/nomad-indexer/values.yaml
@@ -72,6 +72,10 @@ postgresql:
       requests:
         memory: 256Mi # default
         cpu: 2000m
+  # ref: https://github.com/bitnami/charts/blob/master/bitnami/postgresql/values.yaml#L94
+  # ref: https://docs.bitnami.com/kubernetes/infrastructure/postgresql/configuration/change-image-version/
+  image:
+    tag: 11.16.0
 
 prometheus-postgres-exporter:
   # ref: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus-postgres-exporter/values.yaml


### PR DESCRIPTION
Tested on dev and postgres is good to go now 🥳 

- postgres version 11.7 (default for the chart is 14)
- bump chart version + update changelog