### PR TITLE
fix: update prometheus port to match metrics port, bump chart, update  changelog

### DIFF
--- a/charts/nomad-indexer/CHANGELOG.md
+++ b/charts/nomad-indexer/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.0.20
+
+- update prometheus port to match the metrics port
+
 ## 0.0.19
 
 - add note about overriding psql exporter host value

--- a/charts/nomad-indexer/Chart.yaml
+++ b/charts/nomad-indexer/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.19
+version: 0.0.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/nomad-indexer/values.yaml
+++ b/charts/nomad-indexer/values.yaml
@@ -365,7 +365,7 @@ prometheus-postgres-exporter:
 
 podAnnotations:
   prometheus.io/scrape: "true"
-  prometheus.io/port: "9090"
+  prometheus.io/port: "3000"
 
 podCommonLabels: {}
 


### PR DESCRIPTION
prometheus port should match the metrics port (currently at 3000)