### PR TITLE
Fix helm chart to have proper container start command

### DIFF
--- a/charts/nomad-monitor-typescript/templates/monitor-typescript-statefulset.yaml
+++ b/charts/nomad-monitor-typescript/templates/monitor-typescript-statefulset.yaml
@@ -40,7 +40,7 @@ spec:
           {{- if .Values.containerSecurityContext.enabled }}
           securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
           {{- end }}
-          command: ["./monitor"]
+          command: ["yarn", "run", "start"]
           envFrom:
           {{- with .Values.commonEnvFrom }}
           {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
- adding new chart for nomad-monitor-typescript
- fixing helm chart start command
